### PR TITLE
fix: update UserEvent.roles type to match webhook structure

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,7 +51,7 @@ type UserEvent = {
   is_suspended: boolean;
   last_name: string;
   organizations: Array<{
-    roles: string[] | null;
+    roles: { id: string; key: string }[] | null;
     code: string;
     permissions: Array<{
       id: string;


### PR DESCRIPTION
This PR updates the `roles` type inside the `UserEvent.organizations` array in `types.ts`.

The previous type assumed `roles: string[] | null`, but webhook payloads actually return:
roles: { id: string; key: string }[] | null;