### PR TITLE
Readme update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,13 +21,13 @@ pnpm add @kinde/webhooks
 import { decodeWebhook } from "@kinde/webhooks";
 
 // Not sure of the type at decode point
-const decodedWebhook = decodeWebhook("eyJhbGc...");
-if (decodedWebhook.type === WebhookEventType.userCreated) {
+const decodedWebhook = await decodeWebhook("eyJhbGc...", "https://your-subdomain.kinde.com");
+if (decodedWebhook?.type === WebhookEventType.userCreated) {
   // decodedWebhook is type safe userCreated event
 }
 
 // Know the event type at decode point
-const decodedWebhook = decodeWebhook < UserCreatedWebhookEvent > "eyJhbGc...";
+const decodedWebhook = await decodeWebhook<UserCreatedWebhookEvent>("eyJhbGc...", "https://your-subdomain.kinde.com");
 // decodedWebhook is type safe userCreated event
 ```
 


### PR DESCRIPTION
The original readme examples illustrates

```javascript
import { decodeWebhook } from "@kinde/webhook";

// Not sure of the type at decode point
const decodedWebhook = decodeWebhook("eyJhbGc...");
if (decodedWebhook.type === WebhookEventType.userCreated) {
  // decodedWebhook is type safe userCreated event
}

// Know the event type at decode point
const decodedWebhook = decodeWebhook < UserCreatedWebhookEvent > "eyJhbGc...";
// decodedWebhook is type safe userCreated event
```
But decodeWebhook is defined
```javascript
export const decodeWebhook = async <T = WebhookEvent>(
  token?: string,
  domain?: string,
): Promise<T | null>
```