### PR TITLE
fix(build): ship type declarations in the published package

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -30,6 +30,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - run: pnpm build
+      - name: Dist smoke (declaration-packaging regression guard)
+        run: pnpm exec vitest run --config vitest.dist.config.ts
       - run: pnpm test:coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6.0.1

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
+    "test:dist": "pnpm build && vitest run --config vitest.dist.config.ts",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write ."
   },

--- a/test/dist-smoke.test.ts
+++ b/test/dist-smoke.test.ts
@@ -1,0 +1,118 @@
+// Smoke tests against the BUILT package in dist/ (not the lib/ source).
+//
+// These guard the packaging regression fixed in #39: the published tarball
+// shipped no type declarations despite "types": "dist/main.d.ts", and nothing
+// in the source-level suite (lib/main.test.ts imports from ./main) could catch
+// it. Here we assert the real shipped artefacts:
+//   1. the JS bundles named by package.json main/module exist and import, and
+//      the runtime export surface (decodeWebhook, WebhookEventType) works;
+//   2. the declaration files exist where package.json "types" points, and a
+//      consumer importing the event types from the package root type-checks.
+//
+// The suite requires a prior `pnpm build`; run via the `test:dist` script,
+// which builds first.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const distDir = join(repoRoot, "dist");
+
+// Read package.json so the test follows whatever entry points the package
+// advertises, rather than hard-coding filenames.
+const pkg = JSON.parse(
+  execFileSync("node", [
+    "-e",
+    `process.stdout.write(require("fs").readFileSync(${JSON.stringify(
+      join(repoRoot, "package.json"),
+    )}, "utf8"))`,
+  ]).toString(),
+) as { main: string; module: string; types: string };
+
+beforeAll(() => {
+  if (!existsSync(distDir)) {
+    throw new Error(
+      `dist/ not found at ${distDir}. Run \`pnpm build\` first (or use \`pnpm test:dist\`).`,
+    );
+  }
+});
+
+describe("dist runtime (built bundle)", () => {
+  it("ships the JS entry points named by package.json", () => {
+    expect(existsSync(join(repoRoot, pkg.module))).toBe(true); // ESM
+    expect(existsSync(join(repoRoot, pkg.main))).toBe(true); // CJS
+  });
+
+  it("imports the built ESM bundle and exposes the runtime surface", async () => {
+    const mod = await import(join(repoRoot, pkg.module));
+    expect(typeof mod.decodeWebhook).toBe("function");
+    expect(typeof mod.WebhookEventType).toBe("object");
+    expect(mod.WebhookEventType.userCreated).toBe("user.created");
+  });
+
+  it("decodeWebhook from the bundle resolves null for an empty token", async () => {
+    const mod = await import(join(repoRoot, pkg.module));
+    await expect(mod.decodeWebhook("")).resolves.toBeNull();
+  });
+});
+
+describe("dist declarations (#39)", () => {
+  it("ships the declaration file named by package.json types", () => {
+    expect(pkg.types).toBeTruthy();
+    expect(existsSync(join(repoRoot, pkg.types))).toBe(true);
+  });
+
+  it("a consumer importing event types from the package root type-checks", () => {
+    // Spawn tsc against a throwaway consumer that imports from the built
+    // declarations. This reproduces #39's exact failure mode end to end:
+    // before the fix, this import errored TS2307 (no declarations shipped).
+    const work = mkdtempSync(join(tmpdir(), "kinde-webhooks-dts-"));
+    try {
+      writeFileSync(
+        join(work, "consume.ts"),
+        [
+          `import type {`,
+          `  UserUpdatedWebhookEvent,`,
+          `  OrganizationCreatedWebhookEvent,`,
+          `} from "@kinde/webhooks";`,
+          `const a = (x: UserUpdatedWebhookEvent) => x;`,
+          `const b = (y: OrganizationCreatedWebhookEvent) => y;`,
+          `void a;`,
+          `void b;`,
+          ``,
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(work, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            strict: true,
+            moduleResolution: "Bundler",
+            module: "ESNext",
+            target: "ES2022",
+            noEmit: true,
+            skipLibCheck: false,
+            ignoreDeprecations: "6.0",
+            paths: {
+              "@kinde/webhooks": [join(repoRoot, pkg.types)],
+            },
+          },
+          include: ["consume.ts"],
+        }),
+      );
+
+      const tscBin = join(repoRoot, "node_modules", ".bin", "tsc");
+      // Throws (non-zero exit) if the import fails to resolve / type-check.
+      execFileSync(tscBin, ["-p", join(work, "tsconfig.json")], {
+        stdio: "pipe",
+      });
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/dist-smoke.test.ts
+++ b/test/dist-smoke.test.ts
@@ -17,11 +17,16 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..");
 const distDir = join(repoRoot, "dist");
+
+// Dynamic import() needs a file:// URL, not a bare filesystem path: on Windows a
+// drive-letter path (C:\...) is read as a URL scheme and throws
+// ERR_UNSUPPORTED_ESM_URL_SCHEME. pathToFileURL is a no-op-shaped fix on POSIX.
+const importPath = (rel: string) => pathToFileURL(join(repoRoot, rel)).href;
 
 // Read package.json so the test follows whatever entry points the package
 // advertises, rather than hard-coding filenames.
@@ -49,14 +54,14 @@ describe("dist runtime (built bundle)", () => {
   });
 
   it("imports the built ESM bundle and exposes the runtime surface", async () => {
-    const mod = await import(join(repoRoot, pkg.module));
+    const mod = await import(importPath(pkg.module));
     expect(typeof mod.decodeWebhook).toBe("function");
     expect(typeof mod.WebhookEventType).toBe("object");
     expect(mod.WebhookEventType.userCreated).toBe("user.created");
   });
 
   it("decodeWebhook from the bundle resolves null for an empty token", async () => {
-    const mod = await import(join(repoRoot, pkg.module));
+    const mod = await import(importPath(pkg.module));
     await expect(mod.decodeWebhook("")).resolves.toBeNull();
   });
 });
@@ -106,9 +111,13 @@ describe("dist declarations (#39)", () => {
         }),
       );
 
-      const tscBin = join(repoRoot, "node_modules", ".bin", "tsc");
+      // Invoke tsc via Node against its JS entry point, NOT the
+      // node_modules/.bin/tsc shim: on Windows that shim is a `.cmd` wrapper
+      // that execFileSync (no shell) cannot resolve. The TS package's "bin"
+      // entry is the portable, OS-neutral target.
+      const tscJs = join(repoRoot, "node_modules", "typescript", "bin", "tsc");
       // Throws (non-zero exit) if the import fails to resolve / type-check.
-      execFileSync(tscBin, ["-p", join(work, "tsconfig.json")], {
+      execFileSync("node", [tscJs, "-p", join(work, "tsconfig.json")], {
         stdio: "pipe",
       });
     } finally {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,11 +12,15 @@ export default defineConfig({
       fileName: "webhooks",
     },
     target: "es2015",
-    outDir: "../dist",
+    outDir: "dist",
     emptyOutDir: true,
   },
-  root: "lib",
   base: "",
-  resolve: { alias: { src: resolve(__dirname, "./lib") } },
-  plugins: [dts({ insertTypesEntry: true, outDir: "../dist" })],
+  plugins: [
+    dts({
+      insertTypesEntry: true,
+      include: ["lib"],
+      exclude: ["lib/**/*.test.ts", "lib/**/*.spec.ts"],
+    }),
+  ],
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // The default `test` script runs the source suite (lib/). The dist smoke
+    // suite (test/dist-smoke.test.ts) requires a prior build and is run
+    // separately via the `test:dist` script, so it is excluded here.
+    exclude: ["**/node_modules/**", "**/dist/**", "test/**"],
+  },
+});

--- a/vitest.dist.config.ts
+++ b/vitest.dist.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Dist smoke suite only. Runs against the BUILT dist/ (see test/), so it
+    // must be preceded by a build (the `test:dist` script does this).
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
# Explain your changes

Fixes #39.

## Problem

- `@kinde/webhooks` ships no `.d.ts` files despite `package.json` advertising `"types": "dist/main.d.ts"`, so TypeScript consumers get `Cannot find module '@kinde/webhooks' or its corresponding type declarations`.

## Root cause

`vite-plugin-dts` computes each declaration's output path relative to Vite's `root`, which was `"lib"`. 
With `outDir: "../dist"` the `.d.ts` files were written under `lib/dist/` (outside the configured `outDir`), so the plugin's `strictOutput` (on by default) silently skipped writing them. 

- The package therefore shipped only the JS bundles. 
- The `tsc &&` build step also emits nothing because `tsconfig` sets `noEmit`.

## Fix

Remove the left-over `root: "lib"` and the unused `src` alias (nothing depends on them: 
no `index.html`, no `public/`, no `"src"` imports) and set the build `outDir` to `"dist"`. 

Declarations then resolve into the repo-root `dist/` that `files: ["dist"]` publishes. 
`lib/main.ts` already re-exports the event types, so consumers import from the package root. 

## Verification

- `npm pack` now includes `dist/main.d.ts`, `dist/lib/main.d.ts` and
`dist/lib/types.d.ts`.
- A consumer importing event types from `@kinde/webhooks` (package root, not a
`dist/` deep path) type-checks cleanly.
- The JS bundles are byte-for-byte identical to the previous config (matching
SHA-256 for `webhooks.js`, `webhooks.cjs` and both `jsrsasign` chunks), so
runtime output is unchanged.
- The existing suite passes (11/11) and `prettier --check` is clean.
- Adds a dist smoke suite (`pnpm test:dist`) that imports the built bundle and
type-checks a root import, guarding this regression. Verified it fails on the
pre-fix config (`TS2307`) and passes on the fix.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
